### PR TITLE
Make LibCacheSim install compatible for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __pycache__
 .DS_Store
 .vscode
 
+# Folders for local build
+data
+dependencies

--- a/libCacheSim/scripts/install_dependency_windows.sh
+++ b/libCacheSim/scripts/install_dependency_windows.sh
@@ -72,4 +72,4 @@ if [[ ! $GITHUB_ACTIONS == "true" ]]; then
 fi
 setup_zstd
 
-cd $CURR_DIR
+cd "${CURR_DIR}"

--- a/libCacheSim/scripts/install_libcachesim_windows.sh
+++ b/libCacheSim/scripts/install_libcachesim_windows.sh
@@ -1,0 +1,14 @@
+#!/bin/bash 
+set -euo pipefail
+
+
+SOURCE=$(readlink -f ${BASH_SOURCE[0]})
+DIR=$(dirname "${SOURCE}")
+
+cd "${DIR}/../";
+mkdir "_build" || true 2>/dev/null;
+cd "_build";
+cmake ..;
+make -j;
+cd "${DIR}"; 
+


### PR DESCRIPTION
- Removed carriage return characters (\r) from `install.sh` files since on Window systems that virtually host Linux (eg. WSL, Cygwin), those characters are messing with the bash compiler

- Change the `--job/-j` option in `make` for `xgboost` to only use 4 jobs so that computers with smaller onboard memory can still install the dependency without running out of RAM.